### PR TITLE
feat: Add validation for invalid @param.depends parameter references

### DIFF
--- a/src/param_lsp/_treesitter/__init__.py
+++ b/src/param_lsp/_treesitter/__init__.py
@@ -6,6 +6,7 @@ This module provides tree-sitter parsing and navigation utilities.
 from __future__ import annotations
 
 from . import parser, queries
+from .queries import find_decorators
 from .utils import (
     find_all_parameter_assignments,
     find_arguments_in_trailer,
@@ -26,6 +27,7 @@ __all__ = [
     "find_all_parameter_assignments",
     "find_arguments_in_trailer",
     "find_class_suites",
+    "find_decorators",
     "find_function_call_trailers",
     "find_parameter_assignments",
     "get_assignment_target_name",


### PR DESCRIPTION
Add error diagnostics for invalid parameter names in @param.depends decorators. When a parameter name in @param.depends doesn't exist in the Parameterized class, an error is now shown to the user.

Example:
```python
class P(param.Parameterized):
    x = param.Integer(default=1)
    y = param.Integer(default=21)

    @param.depends("x", "y", "z")  # "z" is invalid - shows error
    def test(self): ...
```

Changes:
- Add _check_param_depends_decorators method to ParameterValidator
- Add helper methods to identify and validate param.depends decorators
- Export find_decorators from treesitter module
- Add comprehensive tests for valid and invalid param.depends cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)