### PR TITLE
feat: Add --extra-libraries CLI option for analyzing additional external libraries

### DIFF
--- a/src/param_lsp/_server/base.py
+++ b/src/param_lsp/_server/base.py
@@ -20,18 +20,22 @@ class LSPServerBase(LanguageServer):
     reducing the need for verbose type annotations in mixin methods.
     """
 
-    def __init__(self, *args, python_env: Any = None, **kwargs):
+    def __init__(
+        self, *args, python_env: Any = None, extra_libraries: set[str] | None = None, **kwargs
+    ):
         """
         Initialize the LSP server.
 
         Args:
             python_env: PythonEnvironment instance for analyzing external libraries.
                        If None, uses the current Python environment.
+            extra_libraries: Set of additional external library names to analyze.
         """
         super().__init__(*args, **kwargs)
         self.workspace_root: str | None = None
         self.python_env = python_env
-        self.analyzer = ParamAnalyzer(python_env=python_env)
+        self.extra_libraries = extra_libraries if extra_libraries is not None else set()
+        self.analyzer = ParamAnalyzer(python_env=python_env, extra_libraries=self.extra_libraries)
         self.document_cache: dict[str, dict[str, Any]] = {}
         self.classes = self._get_classes()
 

--- a/src/param_lsp/server.py
+++ b/src/param_lsp/server.py
@@ -257,17 +257,20 @@ def _hover(server, params: HoverParams) -> Hover | None:
     return None
 
 
-def create_server(python_env=None):
+def create_server(python_env=None, extra_libraries=None):
     """Create a Param Language Server instance.
 
     Args:
         python_env: PythonEnvironment instance for analyzing external libraries.
                    If None, uses the current Python environment.
+        extra_libraries: Set of additional external library names to analyze.
 
     Returns:
         ParamLanguageServer instance
     """
-    server = ParamLanguageServer("param-lsp", __version__, python_env=python_env)
+    server = ParamLanguageServer(
+        "param-lsp", __version__, python_env=python_env, extra_libraries=extra_libraries
+    )
 
     # Attach feature handlers
     server.feature("initialize")(lambda params: _initialize(server, params))


### PR DESCRIPTION
Fixes #27 

Adds support for specifying additional external libraries via the --extra-libraries CLI flag. This allows users to analyze libraries beyond the default set (panel, holoviews, param).

Example usage:
  param-lsp --extra-libraries geoviews,datashader --generate-cache

Changes:
- Add --extra-libraries argument to CLI parser
- Thread extra_libraries parameter through call chain: __main__ -> create_server -> LSPServerBase -> ParamAnalyzer -> ExternalClassInspector
- Update ExternalClassInspector to combine ALLOWED_EXTERNAL_LIBRARIES with extra_libraries
- All library checks now use the combined allowed_libraries set

🤖 Generated with [Claude Code](https://claude.com/claude-code)