### PR TITLE
fix: Prevent false positives

### DIFF
--- a/tests/test_analyzer/test_runtime_assignment.py
+++ b/tests/test_analyzer/test_runtime_assignment.py
@@ -401,3 +401,47 @@ instance.style = "wrong"  # Error: wrong type for parameter
             assert "style = None" not in error["message"]
             assert "_widgets" not in error["message"]
             assert "_computed_styler" not in error["message"]
+
+    def test_variable_assignment_ambiguous_parameter_names(self, analyzer):
+        """Test that variable assignments with ambiguous parameter names don't cause false positives.
+
+        This is a regression test for the bug where `slider.value = 10` from
+        `slider = obj.select(FloatSlider)[0]` was incorrectly flagged as a type error
+        because we couldn't determine the type of `slider` and the code would match
+        against ANY external class with a `value` parameter (taking the first match).
+
+        The fix: Only check external classes when there's exactly ONE class with that
+        parameter name, or when multiple classes have the parameter but all with the
+        SAME type.
+
+        This test demonstrates that with the fix, we avoid false positives by not
+        checking assignments when the parameter name is ambiguous across different types.
+        """
+        # Test with Panel and HoloViews external classes
+        code_py = """\
+import panel as pn
+import holoviews as hv
+
+# Simulate scenarios where we can't determine the variable type
+# (e.g., from method calls like obj.layout.select(FloatSlider)[0])
+
+# This should NOT cause errors because we can't determine the type
+# and many widgets have 'value' with different types (String, Number, List, etc.)
+unknown_widget = None  # Type unknown
+if unknown_widget:
+    unknown_widget.value = 10  # Could be FloatSlider (valid) or TextInput (invalid)
+"""
+
+        result = analyzer.analyze_file(code_py)
+
+        runtime_errors = [e for e in result["type_errors"] if e["code"] == "runtime-type-mismatch"]
+        # Should have NO errors because:
+        # 1. We can't determine the type of unknown_widget
+        # 2. Many external classes have 'value' with DIFFERENT types
+        # 3. So we conservatively skip checking to avoid false positives
+        assert len(runtime_errors) == 0
+
+        # Note: The complementary case (where multiple classes have the SAME type)
+        # is already tested in test_holoviews_element_support in
+        # test_external_parameterized_classes.py, which verifies that we DO check
+        # when all matching classes have the same parameter type (e.g., label: String).


### PR DESCRIPTION
When checking runtime parameter assignments like `self.style = None`,
the code was incorrectly matching against ANY external Parameterized
class that had a parameter with the same name, instead of checking
only the containing class's parameters.

This caused false positives when:
1. Inside a class's method (e.g., Tabulator.__init__)
2. Assigning to `self.attribute` where `attribute` is NOT a parameter
3. An unrelated external class (e.g., panel.pane.vizzu.Vizzu) HAS
   a parameter with that name

The fix: When the identifier is `self`, find the containing class
and check only its parameters, rather than searching all external
param classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>